### PR TITLE
fix: sendInitialClientState crashes on dedicated servers (g_client is nil)

### DIFF
--- a/src/RedTapeSettings.lua
+++ b/src/RedTapeSettings.lua
@@ -331,5 +331,5 @@ end)
 FSBaseMission.sendInitialClientState = Utils.appendedFunction(FSBaseMission.sendInitialClientState,
     function(self, connection, user, farm)
         -- Send all RedTape settings to the new client
-        g_client:getServerConnection():sendEvent(RTSettingsEvent.new())
+        connection:sendEvent(RTSettingsEvent.new())
     end)


### PR DESCRIPTION
## Problem

`RedTapeSettings.lua` hooks `FSBaseMission.sendInitialClientState`, which is a **server-side** callback the engine fires once per newly-connecting client so mods can push their state to *that* client (server → client). The hook currently sends the settings event with:

```lua
g_client:getServerConnection():sendEvent(RTSettingsEvent.new())
```

`g_client` is the **client**'s global — it does not exist on a dedicated-server process (it is `nil` there). On a dedicated server this line therefore throws `attempt to index a nil value (global 'g_client')` on **every** client that connects. Because the hook runs inside an engine-invoked `Utils.appendedFunction` (with no surrounding `pcall`), the raised error aborts the rest of the join handshake for that connection, and the connecting client can sit on the loading screen indefinitely.

RedTape's own primary hook already does this the right way — in `RedTape.lua`, `RedTape:sendInitialClientState(connection, user, farm)` sends via `connection:sendEvent(...)`.

## Fix

Use the `connection` argument the callback already receives (the joining client's connection), mirroring the correct pattern used by the mod's other `sendInitialClientState` hook:

```lua
connection:sendEvent(RTSettingsEvent.new())
```

`connection` is the exact target the callback is meant to send to, so this also removes the reliance on `g_client` on a listen-server/host (where it merely happened not to be `nil`). One-line change, scoped to the settings sync.
